### PR TITLE
为NewDirtyManager方法的时间间隔参数添加特殊值-1

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -22,9 +22,11 @@ func NewDirtyManager(store DirtyStore, checkInterval ...time.Duration) *DirtyMan
 		filter:   NewNodeChanFilter(store.Read()),
 		interval: interval,
 	}
-	go func() {
-		manage.checkVersion()
-	}()
+	if (interval != -1) {
+		go func() {
+			manage.checkVersion()
+		}()
+	}
 	return manage
 }
 


### PR DESCRIPTION
-1表示不需要使用间隔时间去自动检查。现有业务场景是不同的敏感词集合针对不同的内容，不会有定时去检测的需求。如果不关闭定时检测，那么内存会一直增长，出现内存泄漏。